### PR TITLE
[Frontend] [Core] add veturboio into model loader

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -566,6 +566,7 @@ class LoadFormat(str, enum.Enum):
     TENSORIZER = "tensorizer"
     SHARDED_STATE = "sharded_state"
     BITSANDBYTES = "bitsandbytes"
+    VETURBOIO = "veturboio"
 
 
 @dataclass

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -165,7 +165,7 @@ class EngineArgs:
             default=EngineArgs.load_format,
             choices=[
                 'auto', 'pt', 'safetensors', 'npcache', 'dummy', 'tensorizer',
-                'bitsandbytes'
+                'bitsandbytes', 'veturboio'
             ],
             help='The format of the model weights to load.\n\n'
             '* "auto" will try to load the weights in the safetensors format '
@@ -181,7 +181,8 @@ class EngineArgs:
             'CoreWeave. See the Tensorize vLLM Model script in the Examples '
             'section for more information.\n'
             '* "bitsandbytes" will load the weights using bitsandbytes '
-            'quantization.\n')
+            'quantization.\n'
+            '* "veturboio" will load the weights using veturboio library.\n')
         parser.add_argument(
             '--dtype',
             type=str,

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -817,6 +817,19 @@ class BitsAndBytesModelLoader(BaseModelLoader):
         return model.eval()
 
 
+class VeturboIOLoader(BaseModelLoader):
+    """Model loader using veturboIO library."""
+
+    def load_model(self, *, model_config: ModelConfig,
+                   device_config: DeviceConfig,
+                   lora_config: Optional[LoRAConfig],
+                   multimodal_config: Optional[MultiModalConfig],
+                   parallel_config: ParallelConfig,
+                   scheduler_config: SchedulerConfig,
+                   cache_config: CacheConfig) -> nn.Module:
+        pass
+
+
 def get_model_loader(load_config: LoadConfig) -> BaseModelLoader:
     """Get a model loader based on the load format."""
 
@@ -834,5 +847,8 @@ def get_model_loader(load_config: LoadConfig) -> BaseModelLoader:
 
     if load_config.load_format == LoadFormat.BITSANDBYTES:
         return BitsAndBytesModelLoader(load_config)
+    
+    if load_config.load_format == LoadConfig.VETURBOIO:
+        return VeturboIOLoader(load_config)
 
     return DefaultModelLoader(load_config)

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -821,6 +821,7 @@ class BitsAndBytesModelLoader(BaseModelLoader):
 
 class VeturboIOLoader(BaseModelLoader):
     """Model loader using veturboIO library."""
+
     def __init__(self, load_config: LoadConfig):
         super().__init__(load_config)
         if isinstance(load_config.model_loader_extra_config, VeturboIOConfig):
@@ -842,16 +843,15 @@ class VeturboIOLoader(BaseModelLoader):
         allow_patterns = ["*.safetensors"]
         if not is_local:
             hf_folder = download_weights_from_hf(model_name_or_path,
-                                            self.load_config.download_dir,
-                                            allow_patterns, revision)
+                                                 self.load_config.download_dir,
+                                                 allow_patterns, revision)
         else:
             hf_folder = model_name_or_path
-            
+
         for pattern in allow_patterns:
-                weight_files = glob.glob(
-                    os.path.join(hf_folder, pattern))
-                if weight_files:
-                    return weight_files, pattern
+            weight_files = glob.glob(os.path.join(hf_folder, pattern))
+            if weight_files:
+                return weight_files, pattern
         raise ValueError("No weight files matched")
 
     def load_model(self, *, model_config: ModelConfig,
@@ -868,8 +868,8 @@ class VeturboIOLoader(BaseModelLoader):
                                           lora_config, multimodal_config,
                                           cache_config)
 
-                hf_weights_files, _ = self._prepare_weights(model_config.model, 
-                                                            model_config.revision)
+                hf_weights_files, _ = self._prepare_weights(
+                    model_config.model, model_config.revision)
                 veturboio_config = copy.copy(self.veturboio_config)
                 veturboio_config.model_files = hf_weights_files
                 veturboio_config.map_location = device_config.device_type
@@ -889,7 +889,6 @@ class VeturboIOLoader(BaseModelLoader):
         return model.eval()
 
 
-
 def get_model_loader(load_config: LoadConfig) -> BaseModelLoader:
     """Get a model loader based on the load format."""
 
@@ -907,7 +906,7 @@ def get_model_loader(load_config: LoadConfig) -> BaseModelLoader:
 
     if load_config.load_format == LoadFormat.BITSANDBYTES:
         return BitsAndBytesModelLoader(load_config)
-    
+
     if load_config.load_format == LoadFormat.VETURBOIO:
         return VeturboIOLoader(load_config)
 

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -825,9 +825,11 @@ class VeturboIOLoader(BaseModelLoader):
         super().__init__(load_config)
         if isinstance(load_config.model_loader_extra_config, VeturboIOConfig):
             self.veturboio_config = load_config.model_loader_extra_config
-        else:
+        elif isinstance(load_config.model_loader_extra_config, dict):
             self.veturboio_config = VeturboIOConfig(
                 **load_config.model_loader_extra_config)
+        else:
+            self.veturboio_config = VeturboIOConfig()
 
     def _verify_config(self, model_config: ModelConfig,
                        parallel_config: ParallelConfig):
@@ -870,7 +872,7 @@ class VeturboIOLoader(BaseModelLoader):
                     model_class, lora_config, multimodal_config)
                 extra_kwargs["quant_config"] = quant_config
                 extra_kwargs["cache_config"] = cache_config
-                _, hf_weights_files, _ = self._prepare_weights(
+                hf_weights_files, _ = self._prepare_weights(
                     model_config.model, model_config.revision)
                 
                 veturboio_config = copy.copy(self.veturboio_config)
@@ -878,6 +880,7 @@ class VeturboIOLoader(BaseModelLoader):
                 veturboio_config.hf_config = model_config.hf_config
                 veturboio_config.dtype = model_config.dtype
                 veturboio_config.model_files = hf_weights_files
+                veturboio_config.map_location = device_config.device_type
 
                 model = load_with_veturboio(veturboio_config, **extra_kwargs)
         return model.eval()

--- a/vllm/model_executor/model_loader/veturboio.py
+++ b/vllm/model_executor/model_loader/veturboio.py
@@ -26,7 +26,7 @@ class VeturboIOConfig:
     model_files: Optional[Tuple[str, os.PathLike]] = None
     map_location: Optional[str] = "cpu"
     enable_fast_mode: Optional[bool] = True
-    num_thread: Optional[int] = 32
+    num_thread: Optional[int] = None
     use_pinmem: Optional[bool] = False
     use_direct_io: Optional[bool] = False
     use_cipher: Optional[bool] = False  # not implemented yet
@@ -103,17 +103,21 @@ def load_with_veturboio_into_model(veturboio_config: VeturboIOConfig,
 class VeturboIOArgs:
     map_location: Optional[str] = "cpu"
     enable_fast_mode: Optional[bool] = True
-    num_thread: Optional[int] = 32
+    num_thread: Optional[int] = None
     use_pinmem: Optional[bool] = False
     use_direct_io: Optional[bool] = False
     use_cipher: Optional[bool] = False  # not implemented yet
 
     def __post_init__(self):
-        self.deserializer_params = {
+        all_params = {
             "map_location": self.map_location,
             "enable_fast_mode": self.enable_fast_mode,
             "num_thread": self.num_thread,
             "use_pinmem": self.use_pinmem,
             "use_direct_io": self.use_direct_io,
             "use_cipher": self.use_cipher,
+        }
+        self.deserializer_params = {
+            k: v
+            for k, v in all_params.items() if v is not None
         }

--- a/vllm/model_executor/model_loader/veturboio.py
+++ b/vllm/model_executor/model_loader/veturboio.py
@@ -86,8 +86,7 @@ class VeturboIOAgent:
             tensors_dict = veturboio.load(model_file, 
                                           helper=helper, 
                                           **self.veturboio_args.deserializer_params)
-        
-            model.load_state_dict(tensors_dict, strict=False, assign=True)
+            model.load_weights(iter(tensors_dict.items()))
             del tensors_dict
             # gc.collect()  # do gc collect immediately
             torch.cuda.empty_cache()

--- a/vllm/model_executor/model_loader/veturboio.py
+++ b/vllm/model_executor/model_loader/veturboio.py
@@ -1,0 +1,132 @@
+import os
+import time
+from dataclasses import dataclass
+from typing import BinaryIO, Generator, Optional, Tuple, Type, Union
+
+from vllm.config import ModelConfig, ParallelConfig
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig)
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+veturboio_error_msg = None
+
+try:
+    import veturboio
+    helper = veturboio.init_io_helper()
+except ImportError as e:
+    veturboio_error_msg = str(e)
+
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class VeturboIOConfig:
+    model_files: Tuple[str, os.PathLike]
+    map_location: Optional[str] = "cpu"
+    enable_fast_mode: Optional[bool] = True
+    num_thread: Optional[int] = 32
+    use_pinmem: Optional[bool] = False
+    use_direct_io: Optional[bool] = False
+    use_cipher: Optional[bool] = False  # not implemented yet
+    model_class: Optional[Type[torch.nn.Module]] = None
+    hf_config: Optional[PretrainedConfig] = None
+    dtype: Optional[Union[str, torch.dtype]] = None
+
+    def _construct_veturboio_args(self) -> "VeturboIOArgs":
+        veturboio_args = {
+            "map_location": self.enable_fast_mode,
+            "enable_fast_mode": self.enable_fast_mode,
+            "num_thread": self.num_thread,
+            "use_pinmem": self.use_pinmem,
+            "use_direct_io": self.use_direct_io,
+            "use_cipher": self.use_cipher,
+        }
+        return VeturboIOArgs(**veturboio_args)
+
+    def verify_with_parallel_config(
+        self,
+        parallel_config: "ParallelConfig",
+    ) -> None:
+        if parallel_config.tensor_parallel_size > 1:
+            raise ValueError(
+                "veturboio does not support tensor parallelism yet")
+
+    def verify_with_model_config(self, model_config: "ModelConfig") -> None:
+        if model_config.quantization is not None:
+            logger.warning(
+                "Loading a model using VeturboIO with quantization on vLLM"
+                " is unstable and may lead to errors.")
+
+
+class VeturboIOAgent:
+
+    def __init__(self, veturboio_config: VeturboIOConfig,
+                 quant_config: QuantizationConfig, **extra_kwargs):
+        if veturboio_error_msg is not None:
+            raise ImportError(
+                "VeturboIO is not installed. Please install ImportError "
+                "to use this feature with `pip install vllm[veturboio]`. "
+                "Error message: {}".format(veturboio_error_msg))
+
+        self.veturboio_config = veturboio_config
+        self.veturboio_args = (
+            self.veturboio_config._construct_veturboio_args())
+        self.extra_kwargs = extra_kwargs
+        if extra_kwargs.get("quant_config", None) is not None:
+            self.quant_config = extra_kwargs["quant_config"]
+        else:
+            self.quant_config = quant_config
+        self.model = self._init_model()
+
+    def _init_model(self):
+        assert self.veturboio_config.hf_config is not None
+        model_args = self.veturboio_config.hf_config
+        model_args.torch_dtype = self.veturboio_config.dtype
+        assert self.veturboio_config.model_class is not None
+        
+        return self.veturboio_config.model_class(config=model_args, 
+                                                 quant_config=self.quant_config, 
+                                                 **self.extra_kwargs)
+        
+    def deserialize(self):
+        start = time.perf_counter()
+        for model_file in self.veturboio_config.model_files:
+            tensors_dict = veturboio.load(model_file, 
+                                          helper=helper,
+                                          **self.veturboio_args.deserializer_params)
+            self.model.load_state_dict(tensors_dict, assign=True)    
+        end = time.perf_counter()
+        duration = end - start
+        logger.info("Deserialized model in %0.2fs by VeturboIO", duration)
+        return self.model.eval()
+
+
+def load_with_veturboio(veturboio_config: VeturboIOConfig,
+                        **extra_kwargs) -> nn.Module:
+    veturboio = VeturboIOAgent(veturboio_config, **extra_kwargs)
+    return veturboio.deserialize()
+
+
+@dataclass
+class VeturboIOArgs:
+    map_location: Optional[str] = "cpu"
+    enable_fast_mode: Optional[bool] = True
+    num_thread: Optional[int] = 32
+    use_pinmem: Optional[bool] = False
+    use_direct_io: Optional[bool] = False
+    use_cipher: Optional[bool] = False  # not implemented yet
+
+    def __post_init__(self):
+        self.deserializer_params = {
+            "map_location": self.map_location,
+            "enable_fast_mode": self.enable_fast_mode,
+            "num_thread": self.num_thread,
+            "use_pinmem": self.use_pinmem,
+            "use_direct_io": self.use_direct_io,
+            "use_cipher": self.use_cipher,
+        }

--- a/vllm/model_executor/model_loader/veturboio.py
+++ b/vllm/model_executor/model_loader/veturboio.py
@@ -1,17 +1,13 @@
-import gc
 import os
 import time
-from dataclasses import dataclass
-from typing import BinaryIO, Generator, Optional, Tuple, Type, Union
-
-from vllm.config import ModelConfig, ParallelConfig
-
-from vllm.logger import init_logger
-from vllm.model_executor.layers.quantization.base_config import (
-    QuantizationConfig)
 import torch
 from torch import nn
-from transformers import PretrainedConfig
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from vllm.config import ModelConfig, ParallelConfig
+from vllm.logger import init_logger
+
 
 veturboio_error_msg = None
 


### PR DESCRIPTION
### Summary

Add [veturboIO](https://github.com/volcengine/veTurboIO) into loader choice. 
The key changes involved are:
- Adds `veturboio` choice into `vllm/engine/arg_utils.py`, enhance `--load-format`
- Adds `veturboio.py` into `vllm/model_executor/model_loader/` that provides utility functions for veturboio.
    - Adds `VeturboIOConfig` that stores all parameters veturboio used.
    - Adds `VeturboIOArgs` that stores the parameters of the veturbio load function.
- Adds `VeturboIOLoader` into `loader.py` that describes th overall process of loading models using veturbio.
### Loading benchmarks
Use docker image `brosoul/vllm-openai:v0.5.1.veturboio` to verify the acceleration of loading. In order to keep the content of the PR clear, the generation of the image will be described in other PR.
```bash
docker run -it --name vllm-e2e --runtime nvidia brosoul/vllm-openai:v0.5.1.veturboio  --host "0.0.0.0" --port "8000" --model deepseek-ai/deepseek-moe-16b-base --served-model-name deepseek-ai/deepseek-moe-16b-base --max-model-len "1296" --trust-remote-code --dtype bfloat16 --load-format veturboio
```
It costs **5.11s (5.25s, 5.20s, 5.11s)** by using `veturboio` load model `deepseek-ai/deepseek-moe-16b-base`,  while it costs **5.71s (5.71s, 5.76s, 5.80s)** by using `auto` loader.