### PR TITLE
[Core] Enable Tensor Parallelism for Vineyard Client

### DIFF
--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, List
 
 import torch
 import torch.distributed
@@ -6,9 +6,9 @@ import torch.distributed
 from .parallel_state import get_tp_group
 
 
-def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+def tensor_model_parallel_all_reduce(input_: torch.Tensor, op: torch.distributed.ReduceOp.SUM) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
-    return get_tp_group().all_reduce(input_)
+    return get_tp_group().all_reduce(input_, op=op)
 
 
 def tensor_model_parallel_all_gather(input_: torch.Tensor,
@@ -23,6 +23,16 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
     """Gather the input tensor across model parallel group."""
     return get_tp_group().gather(input_, dst, dim)
 
+def tensor_model_parallel_broadcast(input_: torch.Tensor,
+                                 src: int = 0,
+                                 ) -> torch.Tensor:
+    """Broadcast the input tensor across model parallel group."""
+    return get_tp_group().broadcast(input_, src)
+
+def model_parallel_broadcast_object_list(input_: List[Any],
+                                 src: int = 0) -> List[Any]:
+    """Broadcast object list across model parallel group."""
+    return get_tp_group().broadcast_object_list(input_, src)
 
 def broadcast_tensor_dict(tensor_dict: Optional[Dict[Any, Union[torch.Tensor,
                                                                 Any]]] = None,

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -29,7 +29,7 @@ def tensor_model_parallel_broadcast(input_: torch.Tensor,
     """Broadcast the input tensor across model parallel group."""
     return get_tp_group().broadcast(input_, src)
 
-def model_parallel_broadcast_object_list(input_: List[Any],
+def tensor_model_parallel_broadcast_object_list(input_: List[Any],
                                  src: int = 0) -> List[Any]:
     """Broadcast object list across model parallel group."""
     return get_tp_group().broadcast_object_list(input_, src)

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -6,9 +6,9 @@ import torch.distributed
 from .parallel_state import get_tp_group
 
 
-def tensor_model_parallel_all_reduce(input_: torch.Tensor, op: torch.distributed.ReduceOp.SUM) -> torch.Tensor:
+def tensor_model_parallel_all_reduce(input_: torch.Tensor, **kwargs) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
-    return get_tp_group().all_reduce(input_, op=op)
+    return get_tp_group().all_reduce(input_, **kwargs)
 
 
 def tensor_model_parallel_all_gather(input_: torch.Tensor,

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -291,7 +291,7 @@ class GroupCoordinator:
             import intel_extension_for_pytorch as ipex
             ipex.distributed.all_reduce(input_, group=self.device_group)
         else:
-            torch.distributed.all_reduce(input_, group=self.device_group, op = operation)
+            torch.distributed.all_reduce(input_, group=self.device_group, op=operation)
         return input_
 
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -292,7 +292,6 @@ class GroupCoordinator:
             ipex.distributed.all_reduce(input_, group=self.device_group)
         else:
             torch.distributed.all_reduce(input_, group=self.device_group, op = operation)
-            # torch.distributed.all_reduce(input_, group=self.device_group)
         return input_
 
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1481,7 +1481,6 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
     _model_input_cls: Type[ModelInputForGPUWithSamplingMetadata] = (
         ModelInputForGPUWithSamplingMetadata)
     _builder_cls: Type[ModelInputForGPUBuilder] = ModelInputForGPUBuilder
-    count = 0
 
     def make_model_input_from_broadcasted_tensor_dict(
         self,

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1516,9 +1516,6 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         If cuda graph is required, this API automatically pads inputs.
         """
         cache_hints = None
-        if self.vineyard_llm_cache and len(kv_caches) > 0 and kv_caches[0] is not None:
-            cache_hints = self.vineyard_llm_cache.prefetch_kv_caches(
-                seq_group_metadata_list, kv_caches, getattr(self, 'block_size', None))
         model_input = self._prepare_model_input_tensors(
             seq_group_metadata_list, finished_requests_ids)
         if get_pp_group().is_last_rank:

--- a/vllm/worker/vineyard_llm_cache.py
+++ b/vllm/worker/vineyard_llm_cache.py
@@ -292,12 +292,11 @@ class VineyardLLMCache:
                 if seq_group_meta.is_prompt:
                     prefill_requests.append(seq_group_meta)
             num_prefill_requests = [len(prefill_requests)]
-            group = get_tp_group()
-            group.broadcast_object_list(num_prefill_requests, src=0)
+            get_tp_group().broadcast_object_list(num_prefill_requests, src=0)
         else:
             num_prefill_requests = [None]
             get_tp_group().broadcast_object_list(num_prefill_requests, src=0)
-            prefill_requests = [None] * num_prefill_requests[0]
+            prefill_requests = [None] *  num_prefill_requests[0]
         num_prefill_requests = num_prefill_requests[0]
         matched = {}
         for seq_group_meta in prefill_requests:

--- a/vllm/worker/vineyard_llm_cache.py
+++ b/vllm/worker/vineyard_llm_cache.py
@@ -147,7 +147,7 @@ class VineyardLLMCache:
         block_size: int,
     ) -> Tuple[str, int]:
         from vllm._custom_ops import reshape_and_cache_flash
-        if seq_group_metadata is not None:
+        if get_tensor_model_parallel_rank() == 0:
             seq_ids = list(seq_group_metadata.seq_data.keys())
             assert len(seq_ids) == 1
             seq_id = seq_ids[0]
@@ -210,7 +210,7 @@ class VineyardLLMCache:
         matched = min(matched, token_chunk_size - 1)
         if matched <= 0:
             return seq_id, 0
-        if seq_group_metadata is not None:
+        if get_tensor_model_parallel_rank() == 0:
             block_table = seq_group_metadata.block_tables[seq_id]
             slot_mapping = []
             for i in range(context_len, context_len + matched):
@@ -316,7 +316,7 @@ class VineyardLLMCache:
         kv_caches: List[torch.Tensor],
         block_size: int,
     ) -> Tuple[str, int]:
-        if seq_group_metadata is not None:
+        if get_tensor_model_parallel_rank() == 0:
             seq_ids = list(seq_group_metadata.seq_data.keys())
             assert len(seq_ids) == 1
             seq_id = seq_ids[0]
@@ -356,7 +356,7 @@ class VineyardLLMCache:
                 seq_data.update_num_computed_tokens(-matched[seq_id])
                 seq_group_metadata.token_chunk_size += matched[seq_id]
             return seq_id, 0
-        if seq_group_metadata is not None:
+        if get_tensor_model_parallel_rank() == 0:
             block_table = seq_group_metadata.block_tables[seq_id]
             slot_mapping = []
             for i in range(update_context_len, update_context_len + update_token_size):
@@ -413,7 +413,7 @@ class VineyardLLMCache:
         if block_size is None or kv_caches[0] is None:  # profile run
             return {}
 
-        if seq_group_metadata_list is not None:
+        if get_tensor_model_parallel_rank() == 0:
             prefill_requests = []
             for seq_group_meta in seq_group_metadata_list:
                 if seq_group_meta.is_prompt:

--- a/vllm/worker/vineyard_llm_cache.py
+++ b/vllm/worker/vineyard_llm_cache.py
@@ -14,7 +14,7 @@ from vllm.config import ModelConfig, ParallelConfig
 from vllm.distributed.parallel_state import (get_tensor_model_parallel_rank,
                                              get_tensor_model_parallel_world_size)
 from vllm.distributed.communication_op import (tensor_model_parallel_all_reduce,
-                                               model_parallel_broadcast_object_list,
+                                               tensor_model_parallel_broadcast_object_list,
                                                tensor_model_parallel_broadcast,)
 from vllm.sequence import (SequenceData, SequenceGroupMetadata)
 from vllm.utils import init_logger, ObjectPool
@@ -283,10 +283,10 @@ class VineyardLLMCache:
                 query_prefix,
                 query_tokens,
             ]
-            model_parallel_broadcast_object_list(query_args, src=0)
+            tensor_model_parallel_broadcast_object_list(query_args, src=0)
         else:
             query_args = [None, None, None, None, None, None, None]
-            model_parallel_broadcast_object_list(query_args, src=0)
+            tensor_model_parallel_broadcast_object_list(query_args, src=0)
             (seq_id,
              context_len,
              token_chunk_size,
@@ -405,10 +405,10 @@ class VineyardLLMCache:
                     if seq_group_meta.is_prompt:
                         prefill_requests.append(seq_group_meta)
             num_prefill_requests = [len(prefill_requests)]
-            model_parallel_broadcast_object_list(num_prefill_requests, src=0)
+            tensor_model_parallel_broadcast_object_list(num_prefill_requests, src=0)
         else:
             num_prefill_requests = [None]
-            model_parallel_broadcast_object_list(num_prefill_requests, src=0)
+            tensor_model_parallel_broadcast_object_list(num_prefill_requests, src=0)
             prefill_requests = [None] *  num_prefill_requests[0]
         num_prefill_requests = num_prefill_requests[0]
         matched = {}
@@ -502,10 +502,10 @@ class VineyardLLMCache:
                 update_prefix,
                 update_tokens,
             ]
-            model_parallel_broadcast_object_list(update_args, src=0)
+            tensor_model_parallel_broadcast_object_list(update_args, src=0)
         else:
             update_args = [None, None, None, None, None]
-            model_parallel_broadcast_object_list(update_args, src=0)
+            tensor_model_parallel_broadcast_object_list(update_args, src=0)
             (seq_id,
              update_context_len,
              update_token_size,
@@ -612,10 +612,10 @@ class VineyardLLMCache:
                 if seq_group_meta.is_prompt:
                     prefill_requests.append(seq_group_meta)
             num_prefill_requests = [len(prefill_requests)]
-            model_parallel_broadcast_object_list(num_prefill_requests, src=0)
+            tensor_model_parallel_broadcast_object_list(num_prefill_requests, src=0)
         else:
             num_prefill_requests = [None]
-            model_parallel_broadcast_object_list(num_prefill_requests, src=0)
+            tensor_model_parallel_broadcast_object_list(num_prefill_requests, src=0)
             prefill_requests = [None] * num_prefill_requests[0]
         num_prefill_requests = num_prefill_requests[0]
 

--- a/vllm/worker/vineyard_llm_cache.py
+++ b/vllm/worker/vineyard_llm_cache.py
@@ -286,11 +286,12 @@ class VineyardLLMCache:
         '''
         if block_size is None or kv_caches[0] is None:  # profile run
             return {}
-        if seq_group_metadata_list is not None:
+        if get_tensor_model_parallel_rank() == 0:
             prefill_requests = []
-            for seq_group_meta in seq_group_metadata_list:
-                if seq_group_meta.is_prompt:
-                    prefill_requests.append(seq_group_meta)
+            if seq_group_metadata_list is not None:
+                for seq_group_meta in seq_group_metadata_list:
+                    if seq_group_meta.is_prompt:
+                        prefill_requests.append(seq_group_meta)
             num_prefill_requests = [len(prefill_requests)]
             get_tp_group().broadcast_object_list(num_prefill_requests, src=0)
         else:

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -343,7 +343,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
 
         model_execute_time = time.perf_counter() - start_time
         # TODO: make update_kv_caches async
-        if self.model_runner.vineyard_llm_cache and self.kv_cache[worker_input.virtual_engine][0] is not None:
+        if self.model_runner.vineyard_llm_cache and len(self.kv_cache[worker_input.virtual_engine]) > 0 and self.kv_cache[worker_input.virtual_engine][0] is not None:
             self.model_runner.vineyard_llm_cache.update_kv_caches(
                 cache_hints, 
                 None if execute_model_req is None else execute_model_req.seq_group_metadata_list, 

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -347,7 +347,6 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         model_execute_time = time.perf_counter() - start_time
         # TODO: make update_kv_caches async
         if self.model_runner.vineyard_llm_cache and self.kv_cache[worker_input.virtual_engine][0] is not None:
-            start_time = time.perf_counter()
             self.model_runner.vineyard_llm_cache.update_kv_caches(
                 cache_hints, 
                 None if execute_model_req is None else execute_model_req.seq_group_metadata_list, 

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -301,16 +301,15 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         """Executes at least one model step on the given sequences, unless no
         sequences are provided."""
         start_time = time.perf_counter()
-            
         cache_hints = None
-        if execute_model_req != None:
-            kv_caches = self.kv_cache[execute_model_req.virtual_engine]
-            if self.model_runner.vineyard_llm_cache and len(kv_caches) > 0 and kv_caches[0] is not None:
-                self.count += 1
-                cache_hints = self.model_runner.vineyard_llm_cache.prefetch_kv_caches(
-                    None if execute_model_req is None else execute_model_req.seq_group_metadata_list, 
-                    kv_caches, 
-                    getattr(self.model_runner, 'block_size', None))
+        virtual_engine_id = 0 if execute_model_req is None else execute_model_req.virtual_engine
+        kv_caches = self.kv_cache[virtual_engine_id]
+        if self.model_runner.vineyard_llm_cache and len(kv_caches) > 0 and kv_caches[0] is not None:
+            self.count += 1
+            cache_hints = self.model_runner.vineyard_llm_cache.prefetch_kv_caches(
+                None if execute_model_req is None else execute_model_req.seq_group_metadata_list, 
+                kv_caches, 
+                getattr(self.model_runner, 'block_size', None))
             
         inputs = self.prepare_input(execute_model_req)
         if inputs is None:
@@ -346,19 +345,14 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         )
 
         model_execute_time = time.perf_counter() - start_time
-        if cache_hints is not None: 
-            print(f"execution time {model_execute_time}")
         # TODO: make update_kv_caches async
         if self.model_runner.vineyard_llm_cache and self.kv_cache[worker_input.virtual_engine][0] is not None:
-            import threading
             start_time = time.perf_counter()
             self.model_runner.vineyard_llm_cache.update_kv_caches(
                 cache_hints, 
                 None if execute_model_req is None else execute_model_req.seq_group_metadata_list, 
                 self.kv_cache[worker_input.virtual_engine], 
                 getattr(self.model_runner, 'block_size', None))
-            duration = time.perf_counter() - start_time
-            print(f"update for seq id {execute_model_req.seq_group_metadata_list[0].request_id} thread {threading.get_ident()} duration {duration} count {self.count} from worker_base")
 
         if not get_pp_group().is_last_rank:
             # output is IntermediateTensors

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -180,7 +180,6 @@ class LocalOrDistributedWorkerBase(WorkerBase):
     is_driver_worker: bool
     model_runner: ModelRunnerBase
     observability_config: Optional[ObservabilityConfig] = None
-    count = 0
 
     @property
     @abstractmethod
@@ -305,7 +304,6 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         virtual_engine_id = 0 if execute_model_req is None else execute_model_req.virtual_engine
         kv_caches = self.kv_cache[virtual_engine_id]
         if self.model_runner.vineyard_llm_cache and len(kv_caches) > 0 and kv_caches[0] is not None:
-            self.count += 1
             cache_hints = self.model_runner.vineyard_llm_cache.prefetch_kv_caches(
                 None if execute_model_req is None else execute_model_req.seq_group_metadata_list, 
                 kv_caches, 

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -230,9 +230,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         assert self.do_metadata_broadcast
         assert not self.is_driver_worker
         broadcast_data = broadcast_tensor_dict(src=0)
-        if not broadcast_data:
-            return None
-
+        assert broadcast_data
         worker_input = WorkerInput.from_broadcasted_tensor_dict(broadcast_data)
         model_input = (
             self.model_runner.make_model_input_from_broadcasted_tensor_dict(
@@ -279,19 +277,11 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         """
         Prepare the inputs to ModelRunner and workers.
         """
-        cache_hints = None
         if self.is_driver_worker:
-            if execute_model_req is None:
-                if self.do_metadata_broadcast:
-                    # This signals that there's no more requests to process for
-                    # now. All workers are running infinite loop with
-                    # broadcast_tensor_dict, and it stops the loop when the
-                    # driver broadcasts an empty input. Send an empty input to
-                    # notify all other workers to stop their execution loop.
-                    broadcast_tensor_dict({}, src=0)
-                return None
             return self._get_driver_input_and_broadcast(execute_model_req)
         else:
+            assert self.do_metadata_broadcast
+            assert not self.is_driver_worker
             return self._get_worker_input_from_broadcast()
 
     def execute_model(
@@ -301,20 +291,35 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         """Executes at least one model step on the given sequences, unless no
         sequences are provided."""
         start_time = time.perf_counter()
-            
         cache_hints = None
-        if execute_model_req != None:
-            kv_caches = self.kv_cache[execute_model_req.virtual_engine]
-            if self.model_runner.vineyard_llm_cache and len(kv_caches) > 0 and kv_caches[0] is not None:
-                self.count += 1
-                cache_hints = self.model_runner.vineyard_llm_cache.prefetch_kv_caches(
-                    None if execute_model_req is None else execute_model_req.seq_group_metadata_list, 
-                    kv_caches, 
-                    getattr(self.model_runner, 'block_size', None))
+        
+        if self.do_metadata_broadcast:
+            if self.is_driver_worker:
+                    # This signals that there's no more requests to process for
+                    # now. All workers are running infinite loop with
+                    # broadcast_tensor_dict, and it stops the loop when the
+                    # driver broadcasts an empty input. Send an empty input to
+                    # notify all other workers to stop their execution loop.
+                    if execute_model_req is None:
+                        broadcast_tensor_dict({}, src=0)
+                        return None
+                    else:
+                        broadcast_tensor_dict({0: torch.empty(0)}, src=0)
+            else:
+                broadcast_data = broadcast_tensor_dict(src=0)
+                if not broadcast_data:
+                    return None
+                
+        
+        kv_caches = self.kv_cache[0]
+        if self.model_runner.vineyard_llm_cache and len(kv_caches) > 0 and kv_caches[0] is not None:
+            self.count += 1
+            cache_hints = self.model_runner.vineyard_llm_cache.prefetch_kv_caches(
+                None if execute_model_req is None else execute_model_req.seq_group_metadata_list, 
+                kv_caches, 
+                getattr(self.model_runner, 'block_size', None))
             
         inputs = self.prepare_input(execute_model_req)
-        if inputs is None:
-            return None
 
         model_input, worker_input, kwargs = inputs
         num_steps = worker_input.num_steps
@@ -346,19 +351,17 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         )
 
         model_execute_time = time.perf_counter() - start_time
-        if cache_hints is not None: 
-            print(f"execution time {model_execute_time}")
         # TODO: make update_kv_caches async
         if self.model_runner.vineyard_llm_cache and self.kv_cache[worker_input.virtual_engine][0] is not None:
             import threading
-            start_time = time.perf_counter()
+            # start_time = time.perf_counter()
             self.model_runner.vineyard_llm_cache.update_kv_caches(
                 cache_hints, 
                 None if execute_model_req is None else execute_model_req.seq_group_metadata_list, 
                 self.kv_cache[worker_input.virtual_engine], 
                 getattr(self.model_runner, 'block_size', None))
-            duration = time.perf_counter() - start_time
-            print(f"update for seq id {execute_model_req.seq_group_metadata_list[0].request_id} thread {threading.get_ident()} duration {duration} count {self.count} from worker_base")
+            # duration = time.perf_counter() - start_time
+            # print(f"update for seq id {execute_model_req.seq_group_metadata_list[0].request_id} thread {threading.get_ident()} duration {duration} count {self.count} from worker_base")
 
         if not get_pp_group().is_last_rank:
             # output is IntermediateTensors

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -278,7 +278,6 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         """
         Prepare the inputs to ModelRunner and workers.
         """
-        cache_hints = None
         if self.is_driver_worker:
             if execute_model_req is None:
                 if self.do_metadata_broadcast:


### PR DESCRIPTION
This branch enables tensor parallelism for cache service client based on Vineyard. It made the following changes:
- Enable all TP handles in cache client (vineyard_llm_cache.py) Helper functions for TP communications (communication_ops.py)
- Move both prefetch/update usage to vllm worker (worker_base.py)
- prefetch_kv_caches (vineyard_llm_caches.py) could run on empty input for a driver worker. The function will broadcast empty input for both driver/non-driver worker in the scenario of an empty input. 

<img width="1492" alt="image" src="https://github.com/user-attachments/assets/752f04d6-9327-448b-ade5-f2956d57e026">

