### PR TITLE
KV cache without dependency on chunked prefill

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -49,7 +49,6 @@ if TYPE_CHECKING:
     VLLM_AUDIO_FETCH_TIMEOUT: int = 5
     VLLM_TARGET_DEVICE: str = "cuda"
     VLLM_USE_VINEYARD_CACHE: Optional[str] = None
-    VLLM_USE_FLASH_ATTN_DECODING: Optional[str] = None
     MAX_JOBS: Optional[str] = None
     NVCC_THREADS: Optional[str] = None
     VLLM_USE_PRECOMPILED: bool = False
@@ -103,10 +102,6 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Enable vineyard kv cache for vLLM.
     "VLLM_USE_VINEYARD_CACHE":
     lambda: os.getenv("VLLM_USE_VINEYARD_CACHE", None),
-    
-    # Enable vineyard kv cache for vLLM.
-    "VLLM_USE_FLASH_ATTN_DECODING":
-    lambda: os.getenv("VLLM_USE_FLASH_ATTN_DECODING", None),
 
     # Maximum number of compilation jobs to run in parallel.
     # By default this is the number of CPUs


### PR DESCRIPTION
- This PR enables KV cache for prefix caching and default mode (without chunked prefill or prefix caching)
- Still depends on `FlashAttentionBackend`.
- If chunked prefill is not enabled:
  - The KV cache will break down the entire request into chunks
  - A double buffering mechanism is used to overlap querying the KV cache (async op) and loading data to the GPU
- If prefix caching is enabled, `computed_block_nums` will be considered when calculating lens

**BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html **
